### PR TITLE
Display test list using TailWindCSS

### DIFF
--- a/src/app/exam/[id]/page.tsx
+++ b/src/app/exam/[id]/page.tsx
@@ -3,7 +3,7 @@ import { Examdetail } from "@/features/exam/components/Examdetail";
 
 export default function ExamDetailPage() {
   return (
-    <div className="container mx-auto p-4">
+    <div>
       <Examdetail />
       <Link href="/exam" className="text-blue-500 hover:underline">
         ← Back to Exam List

--- a/src/app/exam/page.tsx
+++ b/src/app/exam/page.tsx
@@ -2,8 +2,8 @@ import { ExamList } from "@/features/exam/components/Examlist";
 
 export default function ExamPage() {
   return (
-    <div>
-      <h1>Exam List Page</h1>
+    <div className="container mx-auto p-4">
+      <h1 className="text-center">Exam List Page</h1>
       <ExamList />
     </div>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,21 +1,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
-body {
-  color: var(--foreground);
-  background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
-}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,21 @@
 // import { ConfigureAmplifyClientSide } from '@/components/ConfigureAmplify';
+import { Noto_Sans_JP, M_PLUS_Rounded_1c } from "next/font/google";
 import type { Metadata } from 'next';
+import './globals.css';
+
+const noto = Noto_Sans_JP({
+  weight: ["400", "500"],
+  subsets: ["latin"],
+  variable: "--font-Noto-Sans-JP",
+  display: "swap",
+});
+
+const mplus = M_PLUS_Rounded_1c({
+  weight: ["400", "500"],
+  subsets: ["latin"],
+  variable: "--font-M-PLUS-Rounded-1c",
+  display: "swap",
+});
 
 export const metadata: Metadata = {
   title: 'Create Next App',
@@ -13,7 +29,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang='en'>
-      <body>
+      <body className={`${noto.variable} ${mplus.variable} font-noto`}>
         {/* <ConfigureAmplifyClientSide /> */}
         {children}
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 export default function Home() {
   return (
     <div>
-      <h2>NyanHello~</h2>
+      <h1 className="text-3xl font-bold underline">Hello, Next.js!</h1>
       <Link href="/exam">ExamList</Link>
     </div>
   );

--- a/src/features/exam/components/Examlist.tsx
+++ b/src/features/exam/components/Examlist.tsx
@@ -2,15 +2,39 @@ import Prisma from "@/lib/prisma";
 
 export const ExamList = async () => {
   const examList = Prisma.examdata.findMany();
+
+  const getBackgroundClass = (subject: string) => {
+    switch (subject) {
+      case '物理':
+        return 'bg-physics-gradient';
+      case '化学':
+        return 'bg-chemistry-gradient';
+      // 他の科目のクラスを追加
+      default:
+        return 'bg-white';
+    }
+  };
+
   return (
-    <div>
-        <ul>
-            {(await examList).map((exam) => (
-            <li key={exam.id}>
-                <a href={`/exam/${exam.id}`}>{exam.problem_statement}</a>
-            </li>
-            ))}
-        </ul>
+    <div className="container mx-auto p-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {(await examList).map((exam) => (
+          <a
+            href={`/exam/${exam.id}`}
+            key={exam.id}
+            className={`shadow-md rounded-lg p-4 ${getBackgroundClass(exam.subject)}`}
+          >
+            <div className="text-xl line-clamp-1 font-medium font-mplus">
+              第{exam.exam_year}回 : {exam.subject}
+              <span className="text-sm font-normal m-2">
+                ({exam.grade}年)</span>
+            </div>
+            <div className="text-lg line-clamp-1">
+              {exam.problem_statement}
+            </div>
+          </a>
+        ))}
+      </div>
     </div>
   );
-}
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,9 +2,13 @@ import type { Config } from "tailwindcss";
 
 export default {
   content: [
-    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+    './app/**/*.{js,ts,jsx,tsx,mdx}', // Note the addition of the `app` directory.
+    './pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './components/**/*.{js,ts,jsx,tsx,mdx}',
+    './features/**/*.{js,ts,jsx,tsx,mdx}',
+
+    // Or if using `src` directory:
+    './src/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
     extend: {
@@ -12,7 +16,17 @@ export default {
         background: "var(--background)",
         foreground: "var(--foreground)",
       },
+      backgroundImage: {
+        'physics-gradient': 'linear-gradient(to right, #ffffff,rgb(255, 201, 187))', // オレンジ色のグラデーション
+        'chemistry-gradient': 'linear-gradient(to right, #ffffff,rgb(184, 255, 233))', // 緑色のグラデーション
+        // 他の科目のグラデーションを追加
+      },
+      fontFamily: {
+        noto:['var(--font-noto)'],
+        mplus:['var(--font-mplus)'],
+      },
     },
   },
-  plugins: [],
+  plugins: [
+  ],
 } satisfies Config;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -22,8 +22,8 @@ export default {
         // 他の科目のグラデーションを追加
       },
       fontFamily: {
-        noto:['var(--font-noto)'],
-        mplus:['var(--font-mplus)'],
+        noto:["var(--font-Noto-Sans-JP)"],
+        mplus:["var(--font-M-PLUS-Rounded-1c)"],
       },
     },
   },


### PR DESCRIPTION
Implement a card-based layout for the test list, organized in a grid format. Each card displays the year, subject, ID, and problem statement, with optional color coding for subjects. Cleaned up unused styles and applied global fonts across the site.

Fixes #3